### PR TITLE
Fixed README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module.exports = {
 }
 ```
 
-3. Create a file called "WikipediaFetcherList.js" in your "components" folder (./src/components/WikipediaFetcherList.js) and paste in the following
+3. Create a file called "gatsby-wikipedia-fetcher-list.js" in your "components" folder (./src/components/gatsby-wikipedia-fetcher-list.js) and paste in the following
 
 ```javascript
 /**


### PR DESCRIPTION
gatsby-wikipedia-fetcher looks for "gatsby-wikipedia-fetcher-list.js" not for "WikipediaFetcherList.js"